### PR TITLE
Inject changed file into command

### DIFF
--- a/lib/pheonix.js
+++ b/lib/pheonix.js
@@ -14,12 +14,18 @@ module.exports = herit({
     if (this.restart !== '-') this.enableRestart();
   },
 
-  spawn: function () {
+  spawn: function (event, path) {
     if (!this.isDead()) {
       if (this.isAlive()) this.kill();
       return;
     }
-    var child = this.child = child_process.exec(this.command);
+
+    var child = this.child = child_process.exec(this.command, {
+      env: {
+        EVENT: event,
+        FILE: path
+      }
+    });
     this.state = 'alive';
     this.log.info(this.command, 'Spawning...');
     child.on('error', _.bind(this.onError, this));


### PR DESCRIPTION
Allows users to programmatically use $FILE (or $EVENT) in their commands.

Such as:

```
watchy -w lib -- say "\$FILE changed"
```

Note that we escape the $FILE env value otherwise it gets evaluated immediately.

(Please excuse the typo in the actual commit, and the unsolicited PR!)
