### PR TITLE
Don't clobber existing env when adding EVENT and FILE

### DIFF
--- a/lib/pheonix.js
+++ b/lib/pheonix.js
@@ -20,12 +20,8 @@ module.exports = herit({
       return;
     }
 
-    var child = this.child = child_process.exec(this.command, {
-      env: {
-        EVENT: event,
-        FILE: path
-      }
-    });
+    var env = _.defaults({}, process.env, {EVENT: event, FILE: path});
+    var child = this.child = child_process.exec(this.command, {env: env});
     this.state = 'alive';
     this.log.info(this.command, 'Spawning...');
     child.on('error', _.bind(this.onError, this));


### PR DESCRIPTION
This passes the existing `process.env` when creating child processes.  If `EVENT` and `FILE` are not already in `process.env`, they are added (see https://github.com/caseywebdev/watchy/pull/8#issuecomment-63426905).
