### PR TITLE
Preserve color in the child process output.

### DIFF
--- a/lib/pheonix.js
+++ b/lib/pheonix.js
@@ -22,14 +22,13 @@ module.exports = herit({
     }
 
     var child = this.child = child_process.spawn(this.command, this.args, {
-      env: _.extend({EVENT: event || '', FILE: path || ''}, process.env)
+      env: _.extend({EVENT: event || '', FILE: path || ''}, process.env),
+      stdio: ['pipe', process.stdout, process.stderr]
     });
     this.state = 'alive';
     this.log.info(this.command, 'Spawning...');
     child.on('error', _.bind(this.onError, this));
     child.on('close', _.bind(this.onClose, this));
-    child.stdout.pipe(process.stdout);
-    child.stderr.pipe(process.stderr);
     child.stdin.end();
   },
 


### PR DESCRIPTION
Thanks for creating watchy, it's great! One small issue I noticed is that it doesn't seem to preserve colors in the command's output. E.g., I run my tests with `tape test/*.js | tap-spec`, and by default, the colors are lost when I run this using watchy.

This patch seems to fix the problem, and I believe it should produce the same results. In the very least, it works for my use case. :-)