### PR TITLE
Fix bug which caused chokidar to not watch anything

### DIFF
--- a/bin/watchy
+++ b/bin/watchy
@@ -52,7 +52,7 @@ var pheonix = new Pheonix(command, _.rest(argv.args), options);
 // Start watching if paths are specified.
 if (argv.watch) {
   var watcher = chokidar
-    .watch(_.map(argv.watch, function (p) { return path.resolve(p); }), {
+    .watch(_.map(argv.watch, function (p) { return path.resolve(process.cwd(), p); }), {
       ignored: new RegExp(argv.ignore),
       ignoreInitial: true,
       persistent: true,


### PR DESCRIPTION
This may have only my machine but I found that watchy was rather finicky. By changing to force each path to resolve absolutely based off the current working directory (absolute paths provided will not be changed) its ensure that the application can run smoothly.

https://github.com/paulmillr/chokidar/blob/master/index.js#L550

Important to note : we can pass a cwd option to chokidar so they can do the resolving for watchy